### PR TITLE
Correctly remove the `__ultron` property from one time listeners

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,9 +91,12 @@ Ultron.prototype.remove = function remove() {
 
       if (event.listener) {
         if (event.listener.__ultron !== this.id) continue;
-      } else if (event.__ultron !== this.id) continue;
+        delete event.listener.__ultron;
+      } else {
+        if (event.__ultron !== this.id) continue;
+        delete event.__ultron;
+      }
 
-      delete event.__ultron;
       this.ee.removeListener(args[i], event);
     }
   }


### PR DESCRIPTION
The `__ultron` property is attached to the `listener` function when using one time listeners and node built in EventEmitter.

This ensures that the `__ultron` property is removed from the correct function.
